### PR TITLE
Fixes to i2c and gpio drivers

### DIFF
--- a/eiois200_core/eiois200_core.c
+++ b/eiois200_core/eiois200_core.c
@@ -372,7 +372,7 @@ static int pmc_write_cmd(struct device *dev,
 	ret = regmap_write(regmap_is200, eiois200_dev->pmc[id].cmd, value);
 	if (ret)
 		dev_err(dev, "Error PMC write %X:%X\n",
-			eiois200_dev->pmc[id].data, value);
+			eiois200_dev->pmc[id].cmd, value);
 
 	return ret;
 }

--- a/eiois200_core/eiois200_core.c
+++ b/eiois200_core/eiois200_core.c
@@ -408,8 +408,8 @@ static int pmc_read_status(struct device *dev, int id)
 {
 	int val;
 
-	if (regmap_read(regmap_is200, eiois200_dev->pmc[id].data, &val)) {
-		dev_err(dev, "Error PMC read %X\n", eiois200_dev->pmc[id].data);
+	if (regmap_read(regmap_is200, eiois200_dev->pmc[id].status, &val)) {
+		dev_err(dev, "Error PMC read %X\n", eiois200_dev->pmc[id].status);
 		return 0;
 	}
 

--- a/eiois200_thermal/eiois200_thermal.c
+++ b/eiois200_thermal/eiois200_thermal.c
@@ -86,6 +86,9 @@
 /* Beep mechanism no stable. Not supported, yet. */
 #define TRIP_BEEP		 3
 
+#define THERMAL_POLLING_DELAY		2000 /* millisecond */
+#define THERMAL_PASSIVE_DELAY		1000
+
 #define DECI_KELVIN_TO_MILLI_CELSIUS(t) (((t) - 2731) * 100)
 #define MILLI_CELSIUS_TO_DECI_KELVIN(t) ((t / 100) + 2731)
 
@@ -488,7 +491,9 @@ static int probe(struct platform_device *pdev)
 		zone = devm_thermal_zone_device_register(
 				dev, "eiois200_thermal", TRIP_NUM,
 				(1 << TRIP_NUM) - 1, (void *)ch,
-				&zone_ops, &zone_params, 0, 0);
+				&zone_ops, &zone_params,
+				THERMAL_PASSIVE_DELAY,
+				THERMAL_POLLING_DELAY);
 		if (!zone)
 			return PTR_ERR(zone);
 

--- a/eiois200_thermal/eiois200_thermal.c
+++ b/eiois200_thermal/eiois200_thermal.c
@@ -86,8 +86,8 @@
 /* Beep mechanism no stable. Not supported, yet. */
 #define TRIP_BEEP		 3
 
-#define DECI_KELVIN_TO_DECI_CELSIUS(t)	((t) - 2731)
-#define DECI_CELSIUS_TO_DECI_KELVIN(t)	((t) + 2731)
+#define DECI_KELVIN_TO_MILLI_CELSIUS(t) (((t) - 2731) * 100)
+#define MILLI_CELSIUS_TO_DECI_KELVIN(t) ((t / 100) + 2731)
 
 #define DEV_CH(val)		(((long)(val)) >> 8)
 #define DEV_TRIP(val)		(((long)(val)) & 0x0F)
@@ -256,7 +256,7 @@ static int get_temp(struct thermal_zone_device *zone, int *temp)
 
 	/* Query temp */
 	ret = THERM_READ(dev, CTRL_VALUE, id, &val);
-	*temp = DECI_KELVIN_TO_DECI_CELSIUS(val);
+	*temp = DECI_KELVIN_TO_MILLI_CELSIUS(val);
 
 	return ret;
 }
@@ -281,7 +281,7 @@ static int get_trip_temp(struct thermal_zone_device *zone, int trip, int *temp)
 	};
 
 	ret = THERM_READ(&zone->device, ctrl[trip], id, &val);
-	*temp = DECI_KELVIN_TO_DECI_CELSIUS(val);
+	*temp = DECI_KELVIN_TO_MILLI_CELSIUS(val);
 
 	return ret;
 }
@@ -301,7 +301,7 @@ static int set_trip_temp(struct thermal_zone_device *zone, int trip, int temp)
 		return -EINVAL;
 
 	/* Set trigger temp */
-	val = DECI_CELSIUS_TO_DECI_KELVIN(temp);
+	val = MILLI_CELSIUS_TO_DECI_KELVIN(temp);
 	ret = THERM_WRITE(&zone->device, ctrl[trip], id, &val);
 
 	/* Set clear temp */
@@ -320,7 +320,7 @@ static int get_max_state(struct thermal_cooling_device *cdev,
 	int max = 0;
 
 	ret = THERM_READ(&cdev->device, CTRL_MAX, id, &max);
-	*state = DECI_KELVIN_TO_DECI_CELSIUS(max);
+	*state = DECI_KELVIN_TO_MILLI_CELSIUS(max);
 
 	return ret;
 }
@@ -333,7 +333,7 @@ static int get_cur_state(struct thermal_cooling_device *cdev,
 	int temp = 0;
 
 	ret = THERM_READ(&cdev->device, CTRL_VALUE, id, &temp);
-	*state = DECI_KELVIN_TO_DECI_CELSIUS(temp);
+	*state = DECI_KELVIN_TO_MILLI_CELSIUS(temp);
 
 	return ret;
 }
@@ -481,7 +481,7 @@ static int probe(struct platform_device *pdev)
 				dev_err_probe(dev, -EIO, "Read thermal_%ld error\n",
 					      ch);
 
-			temps[trip] = DECI_KELVIN_TO_DECI_CELSIUS(hi[trip]);
+			temps[trip] = DECI_KELVIN_TO_MILLI_CELSIUS(hi[trip]);
 		}
 
 		/* Create zone */

--- a/eiois200_wdt/eiois200_wdt.c
+++ b/eiois200_wdt/eiois200_wdt.c
@@ -219,7 +219,7 @@ static int get_time(u8 ctrl, u32 *val)
 
 static int set_time(u8 ctl, u32 time)
 {
-	/* sec to sec */
+	/* sec to msec */
 	time *= 1000;
 
 	return PMC_WRITE(ctl, &time);

--- a/gpio-eiois200/gpio-eiois200.c
+++ b/gpio-eiois200/gpio-eiois200.c
@@ -128,8 +128,11 @@ static int dir_input(struct gpio_chip *chip, unsigned int offset)
 static int dir_output(struct gpio_chip *chip, unsigned int offset, int value)
 {
 	u8 dir = 1;
+	u8 val = value;
 
-	return pmc_write(GPIO_PIN_DIR, offset, &dir);
+	pmc_write(GPIO_PIN_DIR, offset, &dir);
+
+	return pmc_write(GPIO_PIN_LEVEL, offset, &val);
 }
 
 static int gpio_get(struct gpio_chip *chip, unsigned int offset)
@@ -146,7 +149,9 @@ static int gpio_get(struct gpio_chip *chip, unsigned int offset)
 
 static void gpio_set(struct gpio_chip *chip, unsigned int offset, int value)
 {
-	pmc_write(GPIO_PIN_LEVEL, offset, &value);
+	u8 val = value;
+
+	pmc_write(GPIO_PIN_LEVEL, offset, &val);
 }
 
 static int check_support(void)

--- a/gpio-eiois200/gpio-eiois200.c
+++ b/gpio-eiois200/gpio-eiois200.c
@@ -239,7 +239,7 @@ static int gpio_probe(struct platform_device *pdev)
 	eiois200_dev = dev_get_drvdata(dev->parent);
 	if (!eiois200_dev) {
 		dev_err(dev, "Error contact eiois200_core\n");
-		return -ENOMEM;
+		return -ENODEV;
 	}
 
 	gpio_dev = devm_kzalloc(dev, sizeof(struct _gpio_dev), GFP_KERNEL);

--- a/i2c-eiois200/i2c-eiois200.c
+++ b/i2c-eiois200/i2c-eiois200.c
@@ -165,9 +165,6 @@ struct dev_i2c {
 	struct rt_mutex lock;
 };
 
-/* Pointer to the eiois200_core device structure */
-static struct eiois200_dev *eiois200_dev;
-
 static struct regmap *regmap;
 
 static int timeout = I2C_TIMEOUT;
@@ -903,6 +900,7 @@ static int load_i2c(struct device *dev, enum i2c_ch ch, struct dev_i2c *i2c)
 	int ldn = LDN_I2C0 + ch;
 	int *freqs[] = { &i2c0_freq, &i2c1_freq, &smb0_freq, &smb1_freq };
 	int *freq = freqs[ch];
+	struct eiois200_dev *eiois200_dev = dev_get_drvdata(dev->parent);
 
 	mutex_lock(&eiois200_dev->mutex);
 
@@ -967,12 +965,6 @@ static int probe(struct platform_device *pdev)
 	if ((timeout < I2C_TIMEOUT / 100) || (timeout > I2C_TIMEOUT * 100)) {
 		dev_err(dev, "Error timeout value %d\n", timeout);
 		return -EINVAL;
-	}
-
-	eiois200_dev = dev_get_drvdata(dev->parent);
-	if (!eiois200_dev) {
-		dev_err(dev, "Error contact eiois200_core %d\n", ret);
-		return -ENXIO;
 	}
 
 	regmap = dev_get_regmap(dev->parent, NULL);

--- a/i2c-eiois200/i2c-eiois200.c
+++ b/i2c-eiois200/i2c-eiois200.c
@@ -970,7 +970,7 @@ static int probe(struct platform_device *pdev)
 	regmap = dev_get_regmap(dev->parent, NULL);
 	if (!regmap) {
 		dev_err(dev, "Query parent regmap fail\n");
-		return -ENOMEM;
+		return -ENODEV;
 	}
 
 	for (ch = i2c0; ch < MAX_I2C_SMB; ch++) {

--- a/i2c-eiois200/i2c-eiois200.c
+++ b/i2c-eiois200/i2c-eiois200.c
@@ -474,13 +474,14 @@ static int write_data(struct dev_i2c *i2c, int data, bool no_ack)
 	return wait_write_done(i2c, no_ack);
 }
 
-static int read_data(struct dev_i2c *i2c, void *data)
+static int read_data(struct dev_i2c *i2c, u8 *data)
 {
 	int val, cnt = 0;
 	ktime_t time_end = ktime_add_us(ktime_get(), timeout);
 	int stat = REG_SW(i2c, I2C_REG_STAT, SMB_REG_HS);
 	int target = REG_SW(i2c, I2C_STAT_RXREADY, SMB_HS_RX_READY);
 	int reg = REG_SW(i2c, I2C_REG_DATA, SMB_REG_HD0);
+	unsigned int tmp;
 
 	do {
 		my_delay(cnt++);
@@ -500,7 +501,8 @@ static int read_data(struct dev_i2c *i2c, void *data)
 
 	/* Must read data after clear status	*/
 	/* or error will occur when high speed. */
-	I2C_READ(i2c, reg, data);
+	I2C_READ(i2c, reg, &tmp);
+	data[0] = tmp;
 
 	return 0;
 }

--- a/i2c-eiois200/i2c-eiois200.c
+++ b/i2c-eiois200/i2c-eiois200.c
@@ -744,18 +744,18 @@ static int i2c_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs, int num)
 			let_stop(i2c);
 
 		if (msgs[msg].flags & I2C_M_TEN) {
-			dev_dbg(i2c->dev, "10bits addr: %X\n", addr);
 			addr = I2C_ENC_10BIT_ADDR(msgs[msg].addr);
 			addr |= is_read;
+			dev_dbg(i2c->dev, "10bits addr: %X\n", addr);
 
 			ret = write_addr(i2c, addr >> 8, no_ack);
 			if (!ret)
 				ret = write_data(i2c, addr & 0x7F,
 						 no_ack);
 		} else {
-			dev_dbg(i2c->dev, "7bits addr: %X\n", addr);
 			addr = I2C_ENC_7BIT_ADDR(msgs[msg].addr);
 			addr |= is_read;
+			dev_dbg(i2c->dev, "7bits addr: %X\n", addr);
 
 			ret = write_addr(i2c, addr, no_ack);
 		}


### PR DESCRIPTION
I found two major bugs in the i2c and gpio drivers:

- the i2c driver was corrupting the stack, which crashed the kernel
- the gpio driver was not setting the pin level when setting both the direction _and_ the level

The other fixes are mainly small improvements.